### PR TITLE
choose condor_image in CVMFS when available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to cowtools
 
-Since the tools here are built specifically for the [Wisconsin Analysis Facility](https://cms01.hep.wisc.edu:8000/), they are most easily tested at that Facility. For users of the facility with a custom image
+Since the tools here are built specifically for the [Wisconsin Analysis Facility](http://cms01.hep.wisc.edu/), they are most easily tested at that Facility. For users of the facility with a custom image
 already located at `/scratch/{$USER}/notebook.sif`, one method of testing is to log onto
 cms01.hep.wisc.edu via ssh, and then launch a container that can install `cowtools` via
 `singularity exec --bind /scratch/rsimeon/:/scratch/rsimeon /scratch/rsimeon/notebook.sif /bin/bash`.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This is the `cowtools` package, which is meant to provide convenience Python objects for running physics analyses on the University of Wisconsin-Madison
 Analysis Facility, especially those that use `coffea`.
 
-Intended for use at the Wisconsin Analysis Facility: https://cms01.hep.wisc.edu:8000/
+Intended for use at the Wisconsin Analysis Facility: http://cms01.hep.wisc.edu/
 
 Author: Ryan Simeon

--- a/src/cowtools/__init__.py
+++ b/src/cowtools/__init__.py
@@ -137,7 +137,7 @@ def _find_image():
 
                 # append filename to constructed path
                 cvmfspath = os.path.join(cvmfspath,os.path.basename(container_source))
-                if os.path.isdir(cvmfspath):
+                if os.path.exists(cvmfspath):
                     best_loc = cvmfspath
                     # assume first found location is best
                     break

--- a/src/cowtools/__init__.py
+++ b/src/cowtools/__init__.py
@@ -4,6 +4,11 @@ from pathlib import Path
 from dask_jobqueue import HTCondorCluster
 from dask.distributed import Client
 
+# print when run from command line
+def print_debug(message):
+   if __name__ == "__main__":
+       print(message)
+
 def move_x509():
     '''
     Get x509 path, copy it to the correct location, and return the path. Primarily
@@ -89,6 +94,7 @@ def _find_image():
     if container_info_file.is_file():
         with open(container_info_file) as f:
             container_info = yaml.safe_load(f)
+            print_debug(container_info)
         try:
             container_source = container_info["container_source"]
         except KeyError:


### PR DESCRIPTION
The main purpose of this pull request is to automatically point container_image to the unpacked coffeateam's image in CVMFS which matches the container version which is running the user's Jupyter Notebook.  This will allow us to delete the banner which reminds users to set their container_image manually. If they forget this step, there can be execution errors when condor tries to run dask workers.