### PR TITLE
rename GetCondorClient function keywords to match the dask HTCondorCluster keywords.

### DIFF
--- a/src/cowtools/__init__.py
+++ b/src/cowtools/__init__.py
@@ -4,7 +4,14 @@ from pathlib import Path
 from dask_jobqueue import HTCondorCluster
 from dask.distributed import Client
 
-def GetCondorClient(x509_path=None, container_image=None, maximum=50, memory='2 GB', disk='1 GB'):
+def GetCondorClient(
+    x509_path=None,
+    container_image=None,
+    maximum=None,
+    max_workers=None,    # synonym for 'maximum'
+    memory='2 GB',
+    disk='1 GB'
+):
     '''
     Get a dask.distributed.Client object that can be used for distributed computation with
     an HTCondorCluster. Assumes some default settings for the cluster, including a reasonable
@@ -19,6 +26,17 @@ def GetCondorClient(x509_path=None, container_image=None, maximum=50, memory='2 
     Returns:
         (dask.distributed.Client) A client connected to an HTCondor cluster.
     '''
+
+    # Make maximum and max_workers a synonym
+    if maximum == None and max_workers == None:
+        maximum = 50
+    elif max_workers != None and maximum == None:
+        maximum = max_workers
+    elif max_workers == None and maximum != None:
+        pass
+    else:
+        raise Exception('Only one of max_workers and maximum should be set.')
+
     os.environ["CONDOR_CONFIG"] = "/etc/condor/condor_config"
 
     initial_dir = f"/scratch/{os.environ['USER']}"

--- a/src/cowtools/__init__.py
+++ b/src/cowtools/__init__.py
@@ -172,12 +172,6 @@ def print_debug(message):
        print(message)
 
 # main
-print('Basic usage:')
-print('import cowtools')
-print('client = cowtools.GetCondorClient()')
-print('')
-print('for more usage info visit https://github.com/rpsimeon34/cowtools')
-
 if __name__ == "__main__":
     # for testing at command line, won't be triggered by 'import cowtools'
     GetCondorClient()

--- a/src/cowtools/__init__.py
+++ b/src/cowtools/__init__.py
@@ -28,11 +28,11 @@ def GetCondorClient(
     '''
 
     # Make maximum and max_workers a synonym
-    if maximum == None and max_workers == None:
+    if maximum is None and max_workers is None:
         maximum = 50
-    elif max_workers != None and maximum == None:
+    elif max_workers is not None and maximum is None:
         maximum = max_workers
-    elif max_workers == None and maximum != None:
+    elif max_workers is None and maximum is not None:
         pass
     else:
         raise Exception('Only one of max_workers and maximum should be set.')
@@ -56,7 +56,6 @@ def GetCondorClient(
          "when_to_transfer_output": "ON_EXIT_OR_EVICT",
          "InitialDir": initial_dir,
          'transfer_input_files':[],
-         #"Requirements": "Microarch != \"x86_64-v2\"",
      }
     # set up job_script_prologue
     job_script_prologue = ["export XRD_RUNFORKHANDLER=1"]


### PR DESCRIPTION
Having the keywords for HTCondorCluster match those of GetCondorClient should be easier for users b/c they won't have to learn two separate sets. (Our users have been using HTCondorCluster for awhile now. :) )