### PR TITLE
Change print_debug location

### DIFF
--- a/src/cowtools/__init__.py
+++ b/src/cowtools/__init__.py
@@ -8,11 +8,6 @@ __all__ = [
     "XSecScaler"
 ]
 
-# print when run from command line
-def print_debug(message):
-   if __name__ == "__main__":
-       print(message)
-
 # main
 if __name__ == "__main__":
     # for testing at command line, won't be triggered by 'import cowtools'

--- a/src/cowtools/jobqueue.py
+++ b/src/cowtools/jobqueue.py
@@ -180,3 +180,8 @@ def _find_x509(x509_path):
             return None
 
         return _x509_localpath
+    
+# print when run from command line
+def print_debug(message):
+   if __name__ == "__main__":
+       print(message)


### PR DESCRIPTION
Moves the definition of `print_debug` from `src/cowtools/__init__.py` to `src/cowtools/jobqueue.py`