### PR TITLE
Fix to handle `NoneType` paths

### DIFF
--- a/src/cowtools/jobqueue/jobqueue.py
+++ b/src/cowtools/jobqueue/jobqueue.py
@@ -142,7 +142,8 @@ def _find_env():
         env_path = env_path.strip("\u201c").strip(
             "\u201d"
         )  # Remove extra quotes if they appear
-    return str(Path(env_path).resolve()) # resolve symlinks
+    resolved_path = env_path if env_path is None else str(Path(env_path).resolve()) # resolve symlinks
+    return  resolved_path
 
 
 def _find_env_packages():


### PR DESCRIPTION
In instances when a user is not within a virtual environment, `_find_env()` tried to resolve a `NoneType` into a `Path` object. This PR fixes that bug by resolving a path only if it does not evaluate to `None`. 