### PR TITLE
Warn user if x509 proxy expires soon

### DIFF
--- a/src/cowtools/jobqueue/jobqueue.py
+++ b/src/cowtools/jobqueue/jobqueue.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 import yaml
 from dask.distributed import Client
@@ -9,37 +10,41 @@ from dask_jobqueue import HTCondorCluster
 
 
 def GetCondorClient(
-    x509_path=None,
-    container_image=None,
-    maximum=None,
-    max_workers=None,  # max_workers is synonym for 'maximum'
-    memory="2 GB",
-    disk="1 GB",
-    requirements=None,
-    ship_env=False,
-    transfer_input_files=None,
-    request_GPUs=None,
-):
+    x509_path: Optional[str] = None,
+    container_image: Optional[str] = None,
+    maximum: Optional[int] = None,
+    max_workers: Optional[int] = None,  # max_workers is synonym for 'maximum'
+    memory: str = "2 GB",
+    disk: str = "1 GB",
+    requirements: Optional[str] = None,
+    ship_env: bool = False,
+    transfer_input_files: Optional[List[str]] = None,
+    request_GPUs: Optional[str | int] = None,
+) -> Client:
     """
     Get a dask.distributed.Client object that can be used for distributed computation
     with an HTCondorCluster. Assumes some default settings for the cluster, including
     a reasonable timeout, location for log/output/error files, and image file to ship.
 
-    Inputs:
-        x509_path: (str) Path to the x509 proxy to ship to workers.
-        container_image: (str) Path to the image to be sent to worker nodes. Must be
-                    something that HTCondor accepts under the "container_image"
-                    classAd.
-        ship_env: (bool) If True, run jobs on workers in the same python virtual
-                  environment as the one in which the scheduler operates.
-        transfer_input_files: (list[str]) A python list of filepaths leading to files
-                              to be sent to workers.
-        request_GPUs: (str | int) The number of GPUs per job to request. If None, no
-                      GPUs will be requested. If an int, will be converted into a
-                      string.
+    Parameters
+    ----------
+        x509_path: str
+            Path to the x509 proxy to ship to workers.
+        container_image: str
+            Path to the image to be sent to worker nodes. Must be 
+            something that HTCondor accepts under the "container_image" classAd.
+        ship_env: bool 
+            If True, run jobs on workers in the same python virtual
+            environment as the one in which the scheduler operates.
+        transfer_input_files: List[str]
+            A python list of filepaths leading to files to be sent to workers.
+        request_GPUs: (str | int) 
+            The number of GPUs per job to request. If None, no GPUs will be requested. 
+            If an int, will be converted into a string.
 
-    Returns:
-        (dask.distributed.Client) A client connected to an HTCondor cluster.
+    Returns
+    -------
+        A dask.distributed.Client client connected to an HTCondor cluster.
     """
 
     # Make maximum and max_workers a synonym
@@ -136,7 +141,7 @@ def GetCondorClient(
     return Client(cluster)
 
 
-def _find_env():
+def _find_env() -> None | str:
     # Find the virtual environment and list it as a directory to be transferred
     env_path = os.getenv("VIRTUAL_ENV", None)
     if isinstance(env_path, str):
@@ -147,7 +152,7 @@ def _find_env():
     return  resolved_path
 
 
-def _find_env_packages():
+def _find_env_packages() -> Tuple[List, List]:
     # Find the virtual environment and list it as a directory to be transferred
     try:
         env_path = Path(_find_env())
@@ -172,7 +177,7 @@ def _find_env_packages():
     return pkgs_sched, pkgs_worker
 
 
-def _find_image():
+def _find_image() -> str:
     custom_sif = Path(f"/scratch/{os.environ['USER']}/notebook.sif")
     # If there is a custom SIF at /scratch/${USER}/notebook.sif, use that
     if custom_sif.is_file():
@@ -241,7 +246,7 @@ def _find_image():
     )
 
 
-def _find_x509(x509_path):
+def _find_x509(x509_path: str) -> None | str:
     """
     Attempts to find the voms x509 proxy. Also checks if a found proxy is valid for at least one hour.
     """

--- a/src/cowtools/jobqueue/jobqueue.py
+++ b/src/cowtools/jobqueue/jobqueue.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -242,7 +243,7 @@ def _find_image():
 
 def _find_x509(x509_path):
     """
-    Attempt to find the voms x509 proxy.
+    Attempts to find the voms x509 proxy. Also checks if a found proxy is valid for at least one hour.
     """
 
     if x509_path and os.path.isfile(x509_path):
@@ -254,20 +255,19 @@ def _find_x509(x509_path):
         return None
     else:
         # try to find voms proxy automatically
+        # Check if the proxy is valid for at least one hour
         try:
-            _x509_localpath = (
-                next(
-                    line
-                    for line in os.popen("voms-proxy-info").read().split("\n")
-                    if line.startswith("path")
-                )
-                .split(":")[-1]
-                .strip()
+            subprocess.run(
+                "voms-proxy-info -exists -valid 01:00", shell=True, check=True
             )
-        except Exception:
-            print("Could not find voms proxy, but continuing anyway.")
-            print("Xrootd transfers will most likely fail.")
+        except subprocess.CalledProcessError:
+            print("VOMS proxy either is expired, expires within one hour, or does not exist. Please run `voms-proxy-init -voms cms -rfc -valid 200:0`")
+            print("Continuing anyway, XRootD transfers will most likely fail.")
             return None
+        
+        _x509_localpath = subprocess.check_output(
+            "voms-proxy-info -path", shell=True, text=True
+        ).strip()
 
         return _x509_localpath
 


### PR DESCRIPTION
`voms-proxy-info` has flags that allow you to query the path to the proxy and its validity. Refactored `_find_x509()` to run the command directly using the `subprocess` module to first check if a proxy that is valid for at least an hour exists, and if it does, use the `-path` option to query its path. If the x509 proxy expires soon (invalid proxy), the user is warned and the method returns `None`.

I also added type hints to user-facing functions (`GetCondorClient`) and cleaned up the docstrings a little bit.